### PR TITLE
Recognise “browserslist” file name

### DIFF
--- a/ftdetect/browserslist.vim
+++ b/ftdetect/browserslist.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead .browserslistrc setf browserslist
+autocmd BufNewFile,BufRead .browserslistrc,browserslist setf browserslist


### PR DESCRIPTION
Apart from `.browserslistrc`, a `browserslist` file can also be used:

https://github.com/browserslist/browserslist?tab=readme-ov-file#queries
